### PR TITLE
Results box is now read-only

### DIFF
--- a/static/calculate_score.html
+++ b/static/calculate_score.html
@@ -267,7 +267,7 @@
 
                 <div class="form-text font-weight-bold">
 
-                  <textarea rows="10" cols="100" class="form-control nowrap" id="response" name="response"
+                  <textarea readonly rows="10" cols="100" class="form-control nowrap" id="response" name="response"
                     placeholder="Example Results&#10;You are going to die!"
                     aria-describedby="response to query"></textarea>
 


### PR DESCRIPTION
Probably didn't need a whole branch for this change, but I thought it would take longer.  I just made the results box read-only, so that the user can't change the output.  That should take care of our inability to update the output if the user changes the text in the result box. 
Go team!