### PR TITLE
ensure that if the first param is a -v, we check to make sure there a…

### DIFF
--- a/static/downloadables/runPrsCLI.sh
+++ b/static/downloadables/runPrsCLI.sh
@@ -663,9 +663,10 @@ askToStartMenu() {
 # BEGINNING OF 'MAIN' FUNCTIONALITY
 
 # check to see if they want the version
-if [[ "$1" =~ "--version" ]] || [[ "$1" =~ "-v" ]]; then 
+if [[ "$1" =~ "--version" ]] || [[ "$1" =~ "-v" ]] && [[ -z $2 ]]; then 
     echo -e "Running version ${version}"
     checkForNewVersion
+    exit 1
 fi
 
 # pass arguments to calculatePRS


### PR DESCRIPTION
…ren't other variables after it and then give the version. If there are, then we assume they meant to use it as a parameter in the calculation