### PR TITLE
updated executable bits for sh files

### DIFF
--- a/static/downloadables/CLICMDTesting.sh
+++ b/static/downloadables/CLICMDTesting.sh
@@ -1031,4 +1031,3 @@ for i in "../sample.vcf" "../sample.txt"; do #TODO - we will need to add in the 
     # $timeCommand ./runPrsCLI.sh -f $i -o "$outputFolder/test123${fileType}.tsv" -c $pvalue -r $refGen -p "FIF"
     # echo -e "\n\n\n"
 done
-

--- a/static/downloadables/runPrsCLI.sh
+++ b/static/downloadables/runPrsCLI.sh
@@ -362,7 +362,7 @@ runPRS () {
 # parses the arguments for calculation
 # then calls the scripts required for calculations
 calculatePRS () {
-    # parse arguments 
+    # parse arguments
     traitsForCalc=()
     studyTypesForCalc=()
     studyIDsForCalc=()

--- a/update_database_scripts/master_script.sh
+++ b/update_database_scripts/master_script.sh
@@ -9,7 +9,7 @@
 #   6. do strand flipping on the associations table,
 #   7. upload the new study and association tables as well as the cohort tables to the PRSKB database,
 #   8. create example VCF and rsID files,
-#   9. and create association and clumps download files. 
+#   9. and create association and clumps download files.
 # It usually takes 3-5ish hours to complete on the PRSKB server using 8 downloading nodes. Using the command below, it runs in the background, which means
 # you can leave the server and it will keep running! To see the output, go to the "output.txt" file specified in the command below as well as the 
 # console_files folder for outputs from the data download nodes (see the unpackDatabaseCommandLine.R script).

--- a/update_database_scripts/updateDatabaseCron.sh
+++ b/update_database_scripts/updateDatabaseCron.sh
@@ -5,5 +5,7 @@
 # How to run: ./updateDatabasecron.sh "filePath"
 # where: "filePath" is the path to the passwords file
 
+# cd to where the master script is stored
+cd /var/www/prs.byu.edu/html/update_database_scripts/
 # runs the master script with the password path specified by $1 with 8 subprocesses downloading association data
 ./master_script.sh $1 8


### PR DESCRIPTION
Previously, whenever I pulled files from GitHub to a Linux environment (ie: the PRSKB server), shell files had to be chmoded to be recognized as executable. I am hoping that the vs mode module I installed to make this pull request will work.
You may notice small changes in each of the files unrelated to changed execution bits. This is because on Windows, there must be  a change along with the execution bits for it to go through. If this doesn't work, I will keep looking, but it's impossible to tell without testing it.