### PR TITLE
sort tables on more variables

### DIFF
--- a/update_database_scripts/createStudyTable.R
+++ b/update_database_scripts/createStudyTable.R
@@ -313,7 +313,7 @@ if (is_ebi_reachable()) {
         }
       }, error=function(e){cat("ERROR :",conditionMessage(e), "\n")})
     }
-    studyTable <- arrange(studyTable, trait, citation)
+    studyTable <- arrange(studyTable, trait, citation, studyID, pValueAnnotation, betaAnnotation, ogValueTypes)
     # write out the study table
     write.table(studyTable, file=studyTablePath, sep="\t", row.names=FALSE, quote=FALSE, fileEncoding = "UTF-8")
   }

--- a/update_database_scripts/sortAssociationsTable.R
+++ b/update_database_scripts/sortAssociationsTable.R
@@ -19,7 +19,7 @@ associationsTibble <- read_tsv(associationTablePath, col_types = cols(.default =
 
 # if the id column already exists, remove it for sorting purposes
 if (names(associationsTibble)[1] == "id") {
-  associationsTibble <- select(associationsTibble, -id)
+  associationsTibble <- dplyr::select(associationsTibble, -id)
 }
 
 # sort the table by trait, then citation, then snp

--- a/update_database_scripts/sortAssociationsTable.R
+++ b/update_database_scripts/sortAssociationsTable.R
@@ -5,8 +5,8 @@
 # where "associationTableFolderPath" is the path to the folder where the association table TSV is stored (default: "../tables/")
 
 # get args from the commandline
-args = commandArgs(trailingOnly=TRUE)
-if (length(args)==0) {
+args = commandArgs(trailingOnly = TRUE)
+if (length(args) == 0) {
   args[1] <- "../tables/"
 }
 
@@ -23,7 +23,7 @@ if (names(associationsTibble)[1] == "id") {
 }
 
 # sort the table by trait, then citation, then snp
-associationsTibble <- arrange(associationsTibble, trait, citation, snp) %>%
+associationsTibble <- arrange(associationsTibble, trait, citation, studyID, pValueAnnotation, betaAnnotation, ogValueTypes, snp) %>%
   tibble::rowid_to_column("id")
 
 write_tsv(associationsTibble, associationTablePath, append = FALSE)


### PR DESCRIPTION
The associations table and study table are now sorted on studyID, pValueAnnotation, betaAnnotation, and ogValueTypes. This will make it easier to convert to the .assoc format used by PRSice2 (for testing comparison) and  make linking entries in the associations table to the study table easier.